### PR TITLE
Receive Event in callback (Part 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
   "maple-core-macro",
   "examples/components",
   "examples/counter",
+  "examples/hello",
 ]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ template! {
 
 // Events are attached using the `on:*` directive.
 template! {
-    button(on:click=|| { /* do something */ }) {
+    button(on:click=|_| { /* do something */ }) {
         # "Click me"
     }
 }

--- a/examples/components/src/main.rs
+++ b/examples/components/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     let increment = {
         let state = state.clone();
         let set_state = set_state.clone();
-        move || {
+        move |_| {
             set_state(*state() + 1);
         }
     };

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -17,13 +17,13 @@ fn main() {
         let counter = counter.clone();
         let set_counter = set_counter.clone();
 
-        move || set_counter(*counter() + 1)
+        move |_| set_counter(*counter() + 1)
     };
 
     let reset = {
         let set_counter = set_counter.clone();
 
-        move || set_counter(0)
+        move |_| set_counter(0)
     };
 
     let root = template! {

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors = ["Luke Chu <37006668+lukechu10@users.noreply.github.com>"]
+edition = "2018"
+name = "hello"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+console_error_panic_hook = "0.1.6"
+console_log = "0.2.0"
+log = "0.4.14"
+maple-core = {path = "../../maple-core"}
+wasm-bindgen = "0.2.71"
+
+[dependencies.web-sys]
+features = ["HtmlInputElement", "InputEvent"]
+version = "0.3"

--- a/examples/hello/index.html
+++ b/examples/hello/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Hello World!</title>
+
+    <style>
+      body {
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      }
+    </style>
+  </head>
+  <body></body>
+</html>

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -1,0 +1,45 @@
+#![allow(non_snake_case)]
+
+use maple_core::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{Event, HtmlInputElement};
+
+fn main() {
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    let (name, set_name) = create_signal(String::new());
+
+    let displayed_name = create_memo(move || {
+        if *name() == "" {
+            "World".to_string()
+        } else {
+            name().as_ref().clone()
+        }
+    });
+
+    let handle_change = move |event: Event| {
+        set_name(
+            event
+                .target()
+                .unwrap()
+                .dyn_into::<HtmlInputElement>()
+                .unwrap()
+                .value(),
+        );
+    };
+
+    let root = template! {
+        div {
+            h1 {
+                # "Hello "
+                # displayed_name()
+                # "!"
+            }
+
+            input(on:input=handle_change)
+        }
+    };
+
+    render(root);
+}

--- a/maple-core-macro/src/attributes.rs
+++ b/maple-core-macro/src/attributes.rs
@@ -1,0 +1,72 @@
+use syn::ext::IdentExt;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::Paren;
+use syn::{parenthesized, Expr, Ident, Result, Token};
+
+pub enum AttributeType {
+    /// Syntax: `name`.
+    DomAttribute { name: String },
+    /// Syntax: `on:name`.
+    Event { name: String },
+}
+
+impl Parse for AttributeType {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let ident = input.call(Ident::parse_any)?;
+        let ident_str = ident.to_string();
+
+        if input.peek(Token![:]) {
+            let _colon: Token![:] = input.parse()?;
+            match ident_str.as_str() {
+                "on" => {
+                    let event_name = input.call(Ident::parse_any)?;
+                    Ok(Self::Event {
+                        name: event_name.to_string(),
+                    })
+                }
+                _ => Err(syn::Error::new_spanned(
+                    ident,
+                    format!("unknown directive `{}`", ident_str),
+                )),
+            }
+        } else {
+            Ok(Self::DomAttribute { name: ident_str })
+        }
+    }
+}
+
+pub struct Attribute {
+    pub ty: AttributeType,
+    pub equals_token: Token![=],
+    pub expr: Expr,
+}
+
+impl Parse for Attribute {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            ty: input.parse()?,
+            equals_token: input.parse()?,
+            expr: input.parse()?,
+        })
+    }
+}
+
+pub struct AttributeList {
+    pub paren_token: Paren,
+    pub attributes: Punctuated<Attribute, Token![,]>,
+}
+
+impl Parse for AttributeList {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let paren_token = parenthesized!(content in input);
+
+        let attributes = content.parse_terminated(Attribute::parse)?;
+
+        Ok(Self {
+            paren_token,
+            attributes,
+        })
+    }
+}

--- a/maple-core-macro/src/lib.rs
+++ b/maple-core-macro/src/lib.rs
@@ -1,3 +1,4 @@
+mod attributes;
 mod children;
 mod component;
 mod element;

--- a/maple-core-macro/tests/ui/component-fail.stderr
+++ b/maple-core-macro/tests/ui/component-fail.stderr
@@ -1,4 +1,4 @@
-error: expected an assignment expression
+error: expected ident
   --> $DIR/component-fail.rs:15:27
    |
 15 |     template! { Component(1) };

--- a/maple-core-macro/tests/ui/element-fail.rs
+++ b/maple-core-macro/tests/ui/element-fail.rs
@@ -5,6 +5,7 @@ fn compile_fail() {
 
     template! { button(disabled) };
     template! { button(on:click) };
+    template! { button(unknown:directive="123") };
 
     template! { button(a.b.c="123") };
 }

--- a/maple-core-macro/tests/ui/element-fail.stderr
+++ b/maple-core-macro/tests/ui/element-fail.stderr
@@ -16,8 +16,14 @@ error: expected `=`
 7 |     template! { button(on:click) };
   |                       ^^^^^^^^^^
 
-error: expected `=`
- --> $DIR/element-fail.rs:9:25
+error: unknown directive `unknown`
+ --> $DIR/element-fail.rs:8:24
   |
-9 |     template! { button(a.b.c="123") };
-  |                         ^
+8 |     template! { button(unknown:directive="123") };
+  |                        ^^^^^^^
+
+error: expected `=`
+  --> $DIR/element-fail.rs:10:25
+   |
+10 |     template! { button(a.b.c="123") };
+   |                         ^

--- a/maple-core-macro/tests/ui/element-fail.stderr
+++ b/maple-core-macro/tests/ui/element-fail.stderr
@@ -4,20 +4,20 @@ error: unexpected token
 4 |     template! { p.my-class#id };
   |                  ^
 
-error: expected an assignment expression
- --> $DIR/element-fail.rs:6:24
+error: expected `=`
+ --> $DIR/element-fail.rs:6:23
   |
 6 |     template! { button(disabled) };
-  |                        ^^^^^^^^
+  |                       ^^^^^^^^^^
 
-error: expected an assignment expression
- --> $DIR/element-fail.rs:7:24
+error: expected `=`
+ --> $DIR/element-fail.rs:7:23
   |
 7 |     template! { button(on:click) };
-  |                        ^^^^^^^^
+  |                       ^^^^^^^^^^
 
-error: unexpected token
- --> $DIR/element-fail.rs:9:24
+error: expected `=`
+ --> $DIR/element-fail.rs:9:25
   |
 9 |     template! { button(a.b.c="123") };
-  |                        ^^^^^
+  |                         ^

--- a/maple-core-macro/tests/ui/element-pass.rs
+++ b/maple-core-macro/tests/ui/element-pass.rs
@@ -10,7 +10,7 @@ fn compile_pass() {
     template! { p(class="my-class") };
     template! { p(class="my-class", id="my-id") };
 
-    template! { button(class="my-btn", on:click=|| {}) };
+    template! { button(class="my-btn", on:click=|_| {}) };
 }
 
 fn main() {}

--- a/maple-core/Cargo.toml
+++ b/maple-core/Cargo.toml
@@ -19,6 +19,7 @@ wasm-bindgen = "0.2.71"
 features = [
   "Document",
   "Element",
+  "Event",
   "HtmlElement",
   "Node",
   "Text",

--- a/maple-core/src/internal.rs
+++ b/maple-core/src/internal.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 
 use wasm_bindgen::{prelude::*, JsCast};
-use web_sys::{Element, HtmlElement, Node, Text};
+use web_sys::{Element, Event, HtmlElement, Node, Text};
 
 use crate::reactive::*;
 
@@ -49,11 +49,11 @@ pub fn attr(element: &HtmlElement, name: &str, value: impl Fn() -> String + 'sta
 thread_local! {
     /// A global event listener pool to prevent [`Closure`]s from being deallocated.
     /// TODO: remove events when elements are detached.
-    static EVENT_LISTENERS: RefCell<Vec<Closure<dyn Fn()>>> = RefCell::new(Vec::new());
+    static EVENT_LISTENERS: RefCell<Vec<Closure<dyn Fn(Event)>>> = RefCell::new(Vec::new());
 }
 
 /// Sets an event listener on an [`HtmlElement`].
-pub fn event(element: &HtmlElement, name: &str, handler: Box<dyn Fn()>) {
+pub fn event(element: &HtmlElement, name: &str, handler: Box<dyn Fn(Event)>) {
     let closure = Closure::wrap(handler);
     element
         .add_event_listener_with_callback(name, closure.as_ref().unchecked_ref())

--- a/maple-core/src/lib.rs
+++ b/maple-core/src/lib.rs
@@ -14,6 +14,12 @@ pub mod reactive;
 
 use web_sys::HtmlElement;
 
+/// The result of the `template!` macro. Should not be used directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateResult {
+    element: HtmlElement,
+}
+
 /// Render an [`HtmlElement`] into the DOM.
 pub fn render(template_result: TemplateResult) {
     let window = web_sys::window().unwrap();
@@ -23,12 +29,6 @@ pub fn render(template_result: TemplateResult) {
         .unwrap()
         .append_child(&template_result.element)
         .unwrap();
-}
-
-/// The result of the `template!` macro. Should not be used directly.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TemplateResult {
-    element: HtmlElement,
 }
 
 impl TemplateResult {


### PR DESCRIPTION
Callbacks now accept a parameter of type `Event`.

Part 2 will make the event the appropriate type (e.g. `MouseEvent`, `InputEvent` etc...), depending on the event name.

Closes #12 