### PR TITLE
Component lifecycle

### DIFF
--- a/maple-core/src/lib.rs
+++ b/maple-core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
     pub use crate::cloned;
     pub use crate::reactive::{
         create_effect, create_effect_initial, create_memo, create_root, create_selector,
-        create_selector_with, Signal, StateHandle,
+        create_selector_with, on_cleanup, Signal, StateHandle,
     };
     pub use crate::render::Render;
     pub use crate::{render, TemplateList, TemplateResult};

--- a/maple-core/src/lib.rs
+++ b/maple-core/src/lib.rs
@@ -18,7 +18,6 @@ use web_sys::Node;
 
 use std::cell::RefCell;
 use std::iter::FromIterator;
-use std::rc::Rc;
 
 /// The result of the `template!` macro. Should not be used directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,7 +63,7 @@ pub fn render(template_result: impl FnOnce() -> TemplateResult + 'static) {
     });
 
     thread_local! {
-        static GLOBAL_OWNERS: RefCell<Vec<Rc<RefCell<reactive::Owner>>>> = RefCell::new(Vec::new());
+        static GLOBAL_OWNERS: RefCell<Vec<reactive::Owner>> = RefCell::new(Vec::new());
     }
 
     GLOBAL_OWNERS.with(|global_owners| global_owners.borrow_mut().push(owner));

--- a/maple-core/src/reactive.rs
+++ b/maple-core/src/reactive.rs
@@ -14,36 +14,36 @@ pub use effect::*;
 pub use signal::*;
 
 /// Creates a new reactive root. Generally, you won't need this method as it is called automatically in [`render`](crate::render()).
-/// 
+///
 /// # Example
 /// ```
 /// use maple_core::prelude::*;
-/// 
+///
 /// let trigger = Signal::new(());
 /// let counter = Signal::new(0);
-/// 
+///
 /// let owner = create_root(cloned!((trigger, counter) => move || {
 ///     create_effect(move || {
 ///         trigger.get(); // subscribe to trigger
 ///         counter.set(*counter.get_untracked() + 1);
 ///     });
 /// }));
-/// 
+///
 /// assert_eq!(*counter.get(), 1);
-/// 
+///
 /// trigger.set(());
 /// assert_eq!(*counter.get(), 2);
-/// 
+///
 /// drop(owner);
 /// trigger.set(());
 /// assert_eq!(*counter.get(), 2); // should not be updated because owner was dropped
 /// ```
 #[must_use = "create_root returns the owner of the effects created inside this scope"]
-pub fn create_root(callback: impl FnOnce()) -> Rc<RefCell<Owner>> {
+pub fn create_root(callback: impl FnOnce()) -> Owner {
     OWNER.with(|owner| {
-        *owner.borrow_mut() = Some(Rc::new(RefCell::new(Owner::new())));
+        let outer_owner = owner.replace(Some(Owner::new()));
         callback();
 
-        owner.borrow_mut().as_ref().take().unwrap().clone()
+        owner.replace(outer_owner).unwrap()
     })
 }


### PR DESCRIPTION
Fixes #21 

Adds support for the `on_cleanup` hook. `on_cleanup` is tied to the reactive scope. When the reactive scope (aka `Owner`) is dropped, all the cleanup callbacks are called. Components are created in a new reactive scope so calling `on_cleanup` inside a component will trigger the callback when the component is destroyed.