### PR TITLE
Use Clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Rust
 on: push
 
 env:
+  RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -16,3 +17,5 @@ jobs:
       run: cargo build
     - name: Run tests
       run: cargo test
+    - name: Run clippy
+      run: cargo clippy

--- a/maple-core-macro/src/children.rs
+++ b/maple-core-macro/src/children.rs
@@ -20,7 +20,7 @@ impl Parse for Children {
         }
 
         Ok(Self {
-            brace_token: brace_token,
+            brace_token,
             body,
         })
     }

--- a/maple-core/src/internal.rs
+++ b/maple-core/src/internal.rs
@@ -55,14 +55,16 @@ pub fn attr(element: &HtmlElement, name: &str, value: impl Fn() -> String + 'sta
     })
 }
 
+type EventListener = dyn Fn(Event);
+
 thread_local! {
     /// A global event listener pool to prevent [`Closure`]s from being deallocated.
     /// TODO: remove events when elements are detached.
-    static EVENT_LISTENERS: RefCell<Vec<Closure<dyn Fn(Event)>>> = RefCell::new(Vec::new());
+    static EVENT_LISTENERS: RefCell<Vec<Closure<EventListener>>> = RefCell::new(Vec::new());
 }
 
 /// Sets an event listener on an [`HtmlElement`].
-pub fn event(element: &HtmlElement, name: &str, handler: Box<dyn Fn(Event)>) {
+pub fn event(element: &HtmlElement, name: &str, handler: Box<EventListener>) {
     let closure = Closure::wrap(handler);
     element
         .add_event_listener_with_callback(name, closure.as_ref().unchecked_ref())

--- a/maple-core/src/reactive/effect.rs
+++ b/maple-core/src/reactive/effect.rs
@@ -81,12 +81,15 @@ impl Hash for Callback {
 
 impl PartialEq for Callback {
     fn eq(&self, other: &Self) -> bool {
-        ptr::eq::<_>(Rc::as_ptr(&self.callback()), Rc::as_ptr(&other.callback()))
+        ptr::eq::<()>(
+            Rc::as_ptr(&self.callback()).cast(),
+            Rc::as_ptr(&other.callback()).cast(),
+        )
     }
 }
 impl Eq for Callback {}
 
-/// A [`Week`] backlink to a [`Signal`] for any type `T`.
+/// A [`Weak`] backlink to a [`Signal`] for any type `T`.
 #[derive(Clone)]
 pub(super) struct Dependency(pub(super) Weak<dyn AnySignalInner>);
 
@@ -104,7 +107,10 @@ impl Hash for Dependency {
 
 impl PartialEq for Dependency {
     fn eq(&self, other: &Self) -> bool {
-        ptr::eq::<_>(Rc::as_ptr(&self.signal()), Rc::as_ptr(&other.signal()))
+        ptr::eq::<()>(
+            Rc::as_ptr(&self.signal()).cast(),
+            Rc::as_ptr(&other.signal()).cast(),
+        )
     }
 }
 impl Eq for Dependency {}
@@ -284,7 +290,6 @@ where
         let effect = Rc::new({
             let memo = memo.clone();
             let derived = derived.clone();
-            let comparator = comparator.clone();
             move || {
                 let new_value = derived();
                 if !comparator(&memo.get_untracked(), &new_value) {


### PR DESCRIPTION
Clippy is a useful tool for preventing common mistakes. One mistake it caught in the existing code is that we were comparing `*const dyn Fn`s. This compares the vtable pointer as well as the data pointer, but comparing the vtable pointer is entirely meaningless and could cause bugs, so I changed it to just compare the data pointer.