### PR TITLE
Complete TodoMVC spec conforming implementation

### DIFF
--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -11,10 +11,12 @@ version = "0.1.0"
 console_error_panic_hook = "0.1.6"
 console_log = "0.2.0"
 log = "0.4.14"
-maple-core = {path = "../../maple-core"}
-uuid = {version = "0.8", features = ["v4", "wasm-bindgen"]}
+maple-core = {path = "../../maple-core", features = ["serde"]}
+serde = {version = "1.0.125", features = ["derive"]}
+serde_json = "1.0.64"
+uuid = {version = "0.8", features = ["v4", "wasm-bindgen", "serde"]}
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
-features = ["HtmlInputElement", "InputEvent", "KeyboardEvent"]
+features = ["HtmlInputElement", "InputEvent", "KeyboardEvent", "Storage"]
 version = "0.3"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -12,8 +12,9 @@ console_error_panic_hook = "0.1.6"
 console_log = "0.2.0"
 log = "0.4.14"
 maple-core = {path = "../../maple-core"}
+uuid = {version = "0.8", features = ["v4", "wasm-bindgen"]}
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
-features = ["HtmlInputElement", "InputEvent"]
+features = ["HtmlInputElement", "InputEvent", "KeyboardEvent"]
 version = "0.3"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -18,5 +18,5 @@ uuid = {version = "0.8", features = ["v4", "wasm-bindgen", "serde"]}
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
-features = ["HtmlInputElement", "InputEvent", "KeyboardEvent", "Storage"]
+features = ["HtmlInputElement", "InputEvent", "KeyboardEvent", "Location", "Storage"]
 version = "0.3"

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -3,13 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Todos</title>
+    <title>Maple • TodoMVC</title>
 
-    <style>
-      body {
-        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-      }
-    </style>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.1.2/index.css"
+    />
   </head>
   <body></body>
 </html>

--- a/examples/todomvc/src/copyright.rs
+++ b/examples/todomvc/src/copyright.rs
@@ -1,0 +1,17 @@
+use maple_core::prelude::*;
+
+pub fn Copyright() -> TemplateResult {
+    template! {
+        footer(class="info") {
+            p { "Double click to edit a todo" }
+            p {
+                "Created by "
+                a(href="https://github.com/lukechu10", target="_blank") { "lukechu10" }
+            }
+            p {
+                "Part of "
+                a(href="http://todomvc.com") { "TodoMVC" }
+            }
+        }
+    }
+}

--- a/examples/todomvc/src/footer.rs
+++ b/examples/todomvc/src/footer.rs
@@ -29,7 +29,11 @@ pub fn Footer(app_state: AppState) -> TemplateResult {
 
                         template! {
                             li {
-                                a(class=if selected() { "selected" } else { "" }, on:click=move |_| set_filter(filter)) {
+                                a(
+                                    class=if selected() { "selected" } else { "" },
+                                    href=filter.url(),
+                                    on:click=move |_| set_filter(filter),
+                                ) {
                                     (format!("{:?}", filter))
                                 }
                             }

--- a/examples/todomvc/src/footer.rs
+++ b/examples/todomvc/src/footer.rs
@@ -10,7 +10,12 @@ pub fn Footer(app_state: AppState) -> TemplateResult {
         }
     });
 
+    let has_completed_todos = create_selector(cloned!((app_state) => move || {
+        app_state.todos_left() < app_state.todos.get().len()
+    }));
+
     let app_state2 = app_state.clone();
+    let app_state3 = app_state.clone();
 
     template! {
         footer(class="footer") {
@@ -41,6 +46,16 @@ pub fn Footer(app_state: AppState) -> TemplateResult {
                     })
                 })
             }
+
+            (if *has_completed_todos.get() {
+                template! {
+                    button(class="clear-completed", on:click=cloned!((app_state3) => move |_| app_state3.clear_completed())) {
+                        "Clear completed"
+                    }
+                }
+            } else {
+                TemplateResult::empty()
+            })
         }
     }
 }

--- a/examples/todomvc/src/footer.rs
+++ b/examples/todomvc/src/footer.rs
@@ -1,0 +1,42 @@
+use maple_core::prelude::*;
+
+use crate::{AppState, Filter};
+
+pub fn Footer(app_state: AppState) -> TemplateResult {
+    let items_text = cloned!((app_state) => move || {
+        match app_state.todos_left() {
+            1 => "item",
+            _ => "items"
+        }
+    });
+
+    let app_state2 = app_state.clone();
+
+    template! {
+        footer(class="footer") {
+            span(class="todo-count") {
+                strong { (app_state.todos_left()) }
+                span { " " (items_text()) " left" }
+            }
+            ul(class="filters") {
+                Indexed(IndexedProps {
+                    iterable: Signal::new(vec![Filter::All, Filter::Active, Filter::Completed]).handle(),
+                    template: cloned!((app_state2) => move |filter| {
+                        let selected = cloned!((app_state2) => move || filter == *app_state2.filter.get());
+                        let set_filter = cloned!((app_state2) => move |filter| {
+                            app_state2.filter.set(filter)
+                        });
+
+                        template! {
+                            li {
+                                a(class=if selected() { "selected" } else { "" }, on:click=move |_| set_filter(filter)) {
+                                    (format!("{:?}", filter))
+                                }
+                            }
+                        }
+                    })
+                })
+            }
+        }
+    }
+}

--- a/examples/todomvc/src/header.rs
+++ b/examples/todomvc/src/header.rs
@@ -1,8 +1,8 @@
-use crate::AppState;
-
 use maple_core::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{Event, HtmlInputElement, KeyboardEvent};
+
+use crate::AppState;
 
 pub fn Header(app_state: AppState) -> TemplateResult {
     let value = Signal::new(String::new());

--- a/examples/todomvc/src/header.rs
+++ b/examples/todomvc/src/header.rs
@@ -1,0 +1,44 @@
+use crate::AppState;
+
+use maple_core::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{Event, HtmlInputElement, KeyboardEvent};
+
+pub fn Header(app_state: AppState) -> TemplateResult {
+    let value = Signal::new(String::new());
+
+    let input_ref = NodeRef::new();
+
+    let handle_input = cloned!((value) => move |event: Event| {
+        let target: HtmlInputElement = event.target().unwrap().unchecked_into();
+        value.set(target.value());
+    });
+
+    let handle_submit = cloned!((value, input_ref) => move |event: Event| {
+        let event: KeyboardEvent = event.unchecked_into();
+
+        if event.key() == "Enter" {
+            let mut task = value.get().as_ref().clone();
+            task = task.trim().to_string();
+
+            if !task.is_empty() {
+                app_state.add_todo(task);
+                value.set("".to_string());
+                input_ref.get().unchecked_into::<HtmlInputElement>().set_value(""); // FIXME: bind to value property instead of attribute
+            }
+        }
+    });
+
+    template! {
+        header(class="header") {
+            h1 { "todos" }
+            input(ref=input_ref,
+                class="new-todo",
+                placeholder="What needs to be done?",
+                value=value.get(),
+                on:input=handle_input,
+                on:keyup=handle_submit,
+            )
+        }
+    }
+}

--- a/examples/todomvc/src/header.rs
+++ b/examples/todomvc/src/header.rs
@@ -14,7 +14,7 @@ pub fn Header(app_state: AppState) -> TemplateResult {
         value.set(target.value());
     });
 
-    let handle_submit = cloned!((value, input_ref) => move |event: Event| {
+    let handle_submit = cloned!((app_state, value, input_ref) => move |event: Event| {
         let event: KeyboardEvent = event.unchecked_into();
 
         if event.key() == "Enter" {

--- a/examples/todomvc/src/item.rs
+++ b/examples/todomvc/src/item.rs
@@ -1,0 +1,76 @@
+use maple_core::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{Event, HtmlInputElement, KeyboardEvent};
+
+use crate::{AppState, Todo};
+
+pub fn Item(todo: Todo, app_state: AppState) -> TemplateResult {
+    let task = todo.task.clone();
+    let id = todo.id;
+
+    let editing = Signal::new(false);
+    let input_ref = NodeRef::new();
+
+    let toggle_completed = cloned!((app_state) => move |_| {
+        app_state.toggle_completed(id);
+    });
+
+    let handle_dblclick = cloned!((editing, input_ref) => move |_| {
+        editing.set(true);
+        input_ref.get().unchecked_into::<HtmlInputElement>().focus().unwrap();
+    });
+
+    let handle_blur = cloned!((editing) => move || {
+        editing.set(false);
+    });
+
+    let handle_submit = cloned!((editing, input_ref, handle_blur, task) => move |event: Event| {
+        let event: KeyboardEvent = event.unchecked_into();
+        match event.key().as_str() {
+            "Enter" => handle_blur(),
+            "Escape" => {
+                input_ref.get().unchecked_into::<HtmlInputElement>().set_value(&task);
+                editing.set(false);
+            },
+            _ => {}
+        }
+    });
+
+    let handle_destroy = cloned!((app_state) => move |_| {
+        app_state.remove_todo(id);
+    });
+
+    let completed = todo.completed;
+
+    let class = cloned!((editing) => move || {
+        format!("{} {}",
+            if completed { "completed" } else { "" },
+            if *editing.get() { "editing" } else { "" }
+        )
+    });
+
+    template! {
+        li(class=class()) {
+            div(class="view") {
+                input(class="toggle", type="checkbox", checked=completed, on:input=toggle_completed)
+                label(on:dblclick=handle_dblclick) {
+                    (task.clone())
+                }
+                button(class="destroy", on:click=handle_destroy)
+            }
+
+            (if *editing.get() {
+                cloned!((todo, input_ref, handle_blur, handle_submit) => template! {
+                    input(ref=input_ref,
+                        class="edit",
+                        value=todo.task.clone(),
+                        on:blur=move |_| handle_blur(),
+                        on:keyup=handle_submit,
+                    )
+                })
+            } else {
+                TemplateResult::empty()
+            })
+        }
+    }
+}

--- a/examples/todomvc/src/item.rs
+++ b/examples/todomvc/src/item.rs
@@ -5,7 +5,7 @@ use web_sys::{Event, HtmlInputElement, KeyboardEvent};
 use crate::{AppState, Todo};
 
 pub fn Item(todo: Signal<Todo>, app_state: AppState) -> TemplateResult {
-    let task = cloned!((todo) => move || todo.get().title.clone());
+    let title = cloned!((todo) => move || todo.get().title.clone());
     let completed = create_selector(cloned!((todo) => move || todo.get().completed));
     let id = todo.get().id;
 
@@ -25,9 +25,10 @@ pub fn Item(todo: Signal<Todo>, app_state: AppState) -> TemplateResult {
         });
     });
 
-    let handle_dblclick = cloned!((editing, input_ref) => move |_| {
+    let handle_dblclick = cloned!((title, editing, input_ref, value) => move |_| {
         editing.set(true);
         input_ref.get().unchecked_into::<HtmlInputElement>().focus().unwrap();
+        value.set(title());
     });
 
     let handle_blur = cloned!((todo, app_state, editing, value) => move || {
@@ -46,12 +47,12 @@ pub fn Item(todo: Signal<Todo>, app_state: AppState) -> TemplateResult {
         }
     });
 
-    let handle_submit = cloned!((editing, input_ref, handle_blur, task) => move |event: Event| {
+    let handle_submit = cloned!((editing, input_ref, handle_blur, title) => move |event: Event| {
         let event: KeyboardEvent = event.unchecked_into();
         match event.key().as_str() {
             "Enter" => handle_blur(),
             "Escape" => {
-                input_ref.get().unchecked_into::<HtmlInputElement>().set_value(&task());
+                input_ref.get().unchecked_into::<HtmlInputElement>().set_value(&title());
                 editing.set(false);
             },
             _ => {}
@@ -92,7 +93,7 @@ pub fn Item(todo: Signal<Todo>, app_state: AppState) -> TemplateResult {
                     })
                 })
                 label(on:dblclick=handle_dblclick) {
-                    (task())
+                    (title())
                 }
                 button(class="destroy", on:click=handle_destroy)
             }

--- a/examples/todomvc/src/list.rs
+++ b/examples/todomvc/src/list.rs
@@ -3,8 +3,23 @@ use maple_core::prelude::*;
 use crate::AppState;
 
 pub fn List(app_state: AppState) -> TemplateResult {
+    let todos_left = create_selector(cloned!((app_state) => move || {
+        app_state.todos.get();
+        app_state.todos_left()
+    }));
+
     template! {
         section(class="main") {
+            input(
+                id="toggle-all",
+                class="toggle-all",
+                type="checkbox",
+                checked=*todos_left.get() == 0,
+                readonly=true,
+                on:input=cloned!((app_state) => move |_| app_state.toggle_complete_all())
+            )
+            label(for="toggle-all")
+
             ul(class="todo-list") {
                 Keyed(KeyedProps {
                     iterable: app_state.todos.clone(),

--- a/examples/todomvc/src/list.rs
+++ b/examples/todomvc/src/list.rs
@@ -1,0 +1,19 @@
+use maple_core::prelude::*;
+
+use crate::AppState;
+
+pub fn List(app_state: AppState) -> TemplateResult {
+    template! {
+        section(class="main") {
+            ul(class="todo-list") {
+                Keyed(KeyedProps {
+                    iterable: app_state.todos.clone(),
+                    template: move |todo| template! {
+                        crate::item::Item(todo, app_state.clone())
+                    },
+                    key: |todo| todo.id,
+                })
+            }
+        }
+    }
+}

--- a/examples/todomvc/src/list.rs
+++ b/examples/todomvc/src/list.rs
@@ -1,20 +1,33 @@
 use maple_core::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::HtmlInputElement;
 
 use crate::AppState;
 
 pub fn List(app_state: AppState) -> TemplateResult {
     let todos_left = create_selector(cloned!((app_state) => move || {
-        app_state.todos.get();
         app_state.todos_left()
+    }));
+
+    let input_ref = NodeRef::new();
+
+    // FIXME: bind to boolean attribute
+    create_effect(cloned!((todos_left, input_ref) => move || {
+        let checked = *todos_left.get() == 0;
+
+        if let Some(input_ref) = input_ref.try_get() {
+            input_ref.unchecked_into::<HtmlInputElement>().set_checked(checked);
+        }
     }));
 
     template! {
         section(class="main") {
             input(
+                ref=input_ref,
                 id="toggle-all",
                 class="toggle-all",
                 type="checkbox",
-                checked=*todos_left.get() == 0,
+                // checked=*todos_left.get() == 0,
                 readonly=true,
                 on:input=cloned!((app_state) => move |_| app_state.toggle_complete_all())
             )
@@ -26,7 +39,7 @@ pub fn List(app_state: AppState) -> TemplateResult {
                     template: move |todo| template! {
                         crate::item::Item(todo, app_state.clone())
                     },
-                    key: |todo| todo.id,
+                    key: |todo| todo.get().id,
                 })
             }
         }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -66,6 +66,25 @@ impl AppState {
                 .collect(),
         );
     }
+
+    fn edit_todo_task(&self, id: Uuid, new_task: String) {
+        self.todos.set(
+            self.todos
+                .get()
+                .iter()
+                .map(|todo| {
+                    if todo.id == id {
+                        Todo {
+                            task: new_task.clone(),
+                            ..todo.clone()
+                        }
+                    } else {
+                        todo.clone()
+                    }
+                })
+                .collect(),
+        );
+    }
 }
 
 fn App() -> TemplateResult {
@@ -73,12 +92,15 @@ fn App() -> TemplateResult {
         todos: Signal::new(Vec::new()),
     };
 
+    let todos_is_empty =
+        create_selector(cloned!((app_state) => move || app_state.todos.get().len() > 0));
+
     template! {
         div(class="todomvc-wrapper") {
             section(class="todoapp") {
                 header::Header(app_state.clone())
 
-                (if *create_selector(cloned!((app_state) => move || app_state.todos.get().len() > 0)).get() {
+                (if *todos_is_empty.get() {
                     template! {
                         list::List(app_state.clone())
                     }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -51,7 +51,7 @@ impl AppState {
         );
     }
 
-    fn todos_left(&self) -> u32 {
+    fn todos_left(&self) -> usize {
         self.todos.get().iter().fold(
             0,
             |acc, todo| if todo.get().completed { acc } else { acc + 1 },
@@ -80,6 +80,17 @@ impl AppState {
                 }
             }
         }
+    }
+
+    fn clear_completed(&self) {
+        self.todos.set(
+            self.todos
+                .get()
+                .iter()
+                .filter(|todo| !todo.get().completed)
+                .cloned()
+                .collect(),
+        );
     }
 }
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -99,6 +99,26 @@ pub enum Filter {
     Completed,
 }
 
+impl Filter {
+    fn url(self) -> &'static str {
+        match self {
+            Filter::All => "./#",
+            Filter::Active => "./#/active",
+            Filter::Completed => "./#/completed",
+        }
+    }
+
+    fn get_filter_from_hash() -> Self {
+        let hash = web_sys::window().unwrap().location().hash().unwrap();
+
+        match hash.as_str() {
+            "#/active" => Filter::Active,
+            "#/completed" => Filter::Completed,
+            _ => Filter::All,
+        }
+    }
+}
+
 const KEY: &str = "todos-maple";
 
 fn App() -> TemplateResult {
@@ -116,7 +136,7 @@ fn App() -> TemplateResult {
 
     let app_state = AppState {
         todos,
-        filter: Signal::new(Filter::All),
+        filter: Signal::new(Filter::get_filter_from_hash()),
     };
 
     create_effect(cloned!((local_storage, app_state) => move || {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -7,11 +7,12 @@ mod item;
 mod list;
 
 use maple_core::prelude::*;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Todo {
-    task: String,
+    title: String,
     completed: bool,
     id: Uuid,
 }
@@ -23,7 +24,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    fn add_todo(&self, task: String) {
+    fn add_todo(&self, title: String) {
         self.todos.set(
             self.todos
                 .get()
@@ -31,7 +32,7 @@ impl AppState {
                 .clone()
                 .into_iter()
                 .chain(Some(Signal::new(Todo {
-                    task,
+                    title,
                     completed: false,
                     id: Uuid::new_v4(),
                 })))
@@ -82,6 +83,15 @@ impl AppState {
     }
 }
 
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            todos: Signal::new(Vec::new()),
+            filter: Signal::new(Filter::All),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Filter {
     All,
@@ -89,11 +99,33 @@ pub enum Filter {
     Completed,
 }
 
+const KEY: &str = "todos-maple";
+
 fn App() -> TemplateResult {
+    let local_storage = web_sys::window()
+        .unwrap()
+        .local_storage()
+        .unwrap()
+        .expect("user has not enabled localStorage");
+
+    let todos = if let Ok(Some(app_state)) = local_storage.get_item(KEY) {
+        serde_json::from_str(&app_state).unwrap_or_else(|_| Signal::new(Vec::new()))
+    } else {
+        Signal::new(Vec::new())
+    };
+
     let app_state = AppState {
-        todos: Signal::new(Vec::new()),
+        todos,
         filter: Signal::new(Filter::All),
     };
+
+    create_effect(cloned!((local_storage, app_state) => move || {
+        for todo in app_state.todos.get().iter() {
+            todo.get(); // subscribe to changes in all todos
+        }
+
+        local_storage.set_item(KEY, &serde_json::to_string(app_state.todos.get().as_ref()).unwrap()).unwrap();
+    }));
 
     let todos_is_empty =
         create_selector(cloned!((app_state) => move || app_state.todos.get().len() == 0));

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -85,6 +85,41 @@ impl AppState {
                 .collect(),
         );
     }
+
+    fn todos_left(&self) -> u32 {
+        self.todos
+            .get()
+            .iter()
+            .fold(0, |acc, todo| if todo.completed { acc } else { acc + 1 })
+    }
+
+    fn toggle_complete_all(&self) {
+        if self.todos_left() == 0 {
+            // make all todos active
+            self.todos.set(
+                self.todos
+                    .get()
+                    .iter()
+                    .map(|todo| Todo {
+                        completed: false,
+                        ..todo.clone()
+                    })
+                    .collect(),
+            );
+        } else {
+            // make all todos completed
+            self.todos.set(
+                self.todos
+                    .get()
+                    .iter()
+                    .map(|todo| Todo {
+                        completed: true,
+                        ..todo.clone()
+                    })
+                    .collect(),
+            );
+        }
+    }
 }
 
 fn App() -> TemplateResult {
@@ -93,14 +128,19 @@ fn App() -> TemplateResult {
     };
 
     let todos_is_empty =
-        create_selector(cloned!((app_state) => move || app_state.todos.get().len() > 0));
+        create_selector(cloned!((app_state) => move || app_state.todos.get().len() == 0));
+
+    create_effect(cloned!((todos_is_empty) => move || {
+        log::info!("todos_is_empty = {}", todos_is_empty.get());
+    }));
 
     template! {
         div(class="todomvc-wrapper") {
             section(class="todoapp") {
                 header::Header(app_state.clone())
 
-                (if *todos_is_empty.get() {
+                (if !*todos_is_empty.get() {
+                    log::info!("rendered");
                     template! {
                         list::List(app_state.clone())
                     }

--- a/maple-core-macro/src/component.rs
+++ b/maple-core-macro/src/component.rs
@@ -8,7 +8,7 @@ use syn::{parenthesized, Expr, Path, Result};
 /// Components are identical to function calls.
 pub(crate) struct Component {
     path: Path,
-    paren: Paren,
+    _paren: Paren,
     args: Punctuated<Expr, Comma>,
 }
 
@@ -17,7 +17,7 @@ impl Parse for Component {
         let content;
         Ok(Self {
             path: input.parse()?,
-            paren: parenthesized!(content in input),
+            _paren: parenthesized!(content in input),
             args: content.parse_terminated(Expr::parse)?,
         })
     }
@@ -25,7 +25,7 @@ impl Parse for Component {
 
 impl ToTokens for Component {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Component { path, paren: _, args } = self;
+        let Component { path, _paren: _, args } = self;
 
         let quoted = quote! { ::maple_core::TemplateResult::inner_element(&#path(#args)) };
 

--- a/maple-core-macro/src/component.rs
+++ b/maple-core-macro/src/component.rs
@@ -27,7 +27,7 @@ impl ToTokens for Component {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Component { path, _paren: _, args } = self;
 
-        let quoted = quote! { ::maple_core::TemplateResult::inner_element(&#path(#args)) };
+        let quoted = quote! { ::maple_core::reactive::untrack(|| ::maple_core::TemplateResult::inner_element(&#path(#args))) };
 
         tokens.extend(quoted);
     }

--- a/maple-core-macro/src/component.rs
+++ b/maple-core-macro/src/component.rs
@@ -1,26 +1,33 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
-use syn::{ExprCall, Result};
+use syn::punctuated::Punctuated;
+use syn::token::{Comma, Paren};
+use syn::{parenthesized, Expr, Path, Result};
 
 /// Components are identical to function calls.
 pub(crate) struct Component {
-    expr_call: ExprCall,
+    path: Path,
+    paren: Paren,
+    args: Punctuated<Expr, Comma>,
 }
 
 impl Parse for Component {
     fn parse(input: ParseStream) -> Result<Self> {
+        let content;
         Ok(Self {
-            expr_call: input.parse()?,
+            path: input.parse()?,
+            paren: parenthesized!(content in input),
+            args: content.parse_terminated(Expr::parse)?,
         })
     }
 }
 
 impl ToTokens for Component {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Component { expr_call } = self;
+        let Component { path, paren: _, args } = self;
 
-        let quoted = quote! { ::maple_core::TemplateResult::inner_element(&#expr_call) };
+        let quoted = quote! { ::maple_core::TemplateResult::inner_element(&#path(#args)) };
 
         tokens.extend(quoted);
     }

--- a/maple-core-macro/src/lib.rs
+++ b/maple-core-macro/src/lib.rs
@@ -32,7 +32,7 @@ impl HtmlTree {
         } else if input.peek(Token![::]) {
             Some(HtmlType::Component)
         } else if input.peek(Ident::peek_any) {
-            let ident: Ident = input.parse().ok()?;
+            let ident: Ident = input.call(Ident::parse_any).ok()?;
             let ident = ident.to_string();
 
             if ident.chars().next().unwrap().is_ascii_uppercase() || input.peek(Token![::]) {

--- a/maple-core-macro/src/lib.rs
+++ b/maple-core-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::eval_order_dependence)] // Needed when using `syn::parenthesized!`.
+
 mod attributes;
 mod children;
 mod component;

--- a/maple-core-macro/tests/ui/component-fail.stderr
+++ b/maple-core-macro/tests/ui/component-fail.stderr
@@ -1,8 +1,10 @@
-error: expected function call expression
-  --> $DIR/component-fail.rs:14:17
+error: unexpected end of input, expected parentheses
+  --> $DIR/component-fail.rs:14:5
    |
 14 |     template! { Component };
-   |                 ^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function, tuple struct or tuple variant `UnknownComponent` in this scope
   --> $DIR/component-fail.rs:12:17

--- a/maple-core/Cargo.toml
+++ b/maple-core/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.3.1"
 
 [dependencies]
 maple-core-macro = {path = "../maple-core-macro", version = "0.3.1"}
+serde = {version = "1.0", optional = true}
 wasm-bindgen = "0.2.72"
 
 [dependencies.web-sys]

--- a/maple-core/src/flow.rs
+++ b/maple-core/src/flow.rs
@@ -23,7 +23,7 @@ where
     K: Fn(&T) -> Key,
     Key: Hash + Eq,
 {
-    pub iterable: Signal<Vec<T>>,
+    pub iterable: StateHandle<Vec<T>>,
     pub template: F,
     pub key: K,
 }
@@ -41,7 +41,7 @@ where
 ///
 /// let node = template! {
 ///     Keyed(KeyedProps {
-///         iterable: count,
+///         iterable: count.handle(),
 ///         template: |item| template! {
 ///             li { (item) }
 ///         },
@@ -185,7 +185,7 @@ pub struct IndexedProps<T: 'static, F>
 where
     F: Fn(T) -> TemplateResult,
 {
-    pub iterable: Signal<Vec<T>>,
+    pub iterable: StateHandle<Vec<T>>,
     pub template: F,
 }
 
@@ -202,7 +202,7 @@ where
 ///
 /// let node = template! {
 ///     Indexed(IndexedProps {
-///         iterable: count,
+///         iterable: count.handle(),
 ///         template: |item| template! {
 ///             li { (item) }
 ///         },

--- a/maple-core/src/lib.rs
+++ b/maple-core/src/lib.rs
@@ -36,9 +36,21 @@ pub struct TemplateResult {
 }
 
 impl TemplateResult {
-    /// Create a new `TemplateResult` from a [`Node`].
+    /// Create a new [`TemplateResult`] from a [`Node`].
     pub fn new(node: Node) -> Self {
         Self { node }
+    }
+
+    /// Create a new [`TemplateResult`] with a blank comment node
+    pub fn empty() -> Self {
+        Self::new(
+            web_sys::window()
+                .unwrap()
+                .document()
+                .unwrap()
+                .create_comment("")
+                .into(),
+        )
     }
 
     pub fn inner_element(&self) -> Node {

--- a/maple-core/src/lib.rs
+++ b/maple-core/src/lib.rs
@@ -100,7 +100,7 @@ pub mod prelude {
     pub use crate::noderef::NodeRef;
     pub use crate::reactive::{
         create_effect, create_effect_initial, create_memo, create_root, create_selector,
-        create_selector_with, on_cleanup, Signal, SignalVec, StateHandle,
+        create_selector_with, on_cleanup, untrack, Signal, SignalVec, StateHandle,
     };
     pub use crate::render::Render;
     pub use crate::{render, render_to, TemplateList, TemplateResult};

--- a/maple-core/src/lib.rs
+++ b/maple-core/src/lib.rs
@@ -6,6 +6,9 @@
 //!
 //! ## Supported Targets
 //! - `wasm32-unknown-unknown`
+//!
+//! ## Features
+//! - `serde` - Enables serializing and deserializing `Signal`s and other wrapper types using `serde`.
 
 #![allow(non_snake_case)]
 #![warn(clippy::clone_on_ref_ptr)]

--- a/maple-core/src/reactive/signal.rs
+++ b/maple-core/src/reactive/signal.rs
@@ -1,6 +1,7 @@
 use super::*;
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -61,6 +62,14 @@ impl<T: 'static> StateHandle<T> {
 impl<T: 'static> Clone for StateHandle<T> {
     fn clone(&self) -> Self {
         Self(Rc::clone(&self.0))
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for StateHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StateHandle")
+            .field(&self.get_untracked())
+            .finish()
     }
 }
 
@@ -156,6 +165,14 @@ impl<T: 'static> Clone for Signal<T> {
         Self {
             handle: self.handle.clone(),
         }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Signal<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Signal")
+            .field(&self.get_untracked())
+            .finish()
     }
 }
 

--- a/maple-core/src/reactive/signal.rs
+++ b/maple-core/src/reactive/signal.rs
@@ -168,6 +168,12 @@ impl<T: 'static> Clone for Signal<T> {
     }
 }
 
+impl<T: PartialEq> PartialEq for Signal<T> {
+    fn eq(&self, other: &Signal<T>) -> bool {
+        self.get_untracked().eq(&other.get_untracked())
+    }
+}
+
 impl<T: fmt::Debug> fmt::Debug for Signal<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Signal")

--- a/maple-core/src/reactive/signal.rs
+++ b/maple-core/src/reactive/signal.rs
@@ -73,6 +73,26 @@ impl<T: fmt::Debug> fmt::Debug for StateHandle<T> {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<T: serde::Serialize> serde::Serialize for StateHandle<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.get_untracked().as_ref().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for StateHandle<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Signal::new(T::deserialize(deserializer)?).handle())
+    }
+}
+
 /// State that can be set.
 ///
 /// # Example
@@ -179,6 +199,26 @@ impl<T: fmt::Debug> fmt::Debug for Signal<T> {
         f.debug_tuple("Signal")
             .field(&self.get_untracked())
             .finish()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: serde::Serialize> serde::Serialize for Signal<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.get_untracked().as_ref().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Signal<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Signal::new(T::deserialize(deserializer)?))
     }
 }
 

--- a/maple-core/tests/integration.rs
+++ b/maple-core/tests/integration.rs
@@ -100,7 +100,7 @@ fn non_keyed() {
     let node = cloned!((count) => template! {
         ul {
             Indexed(IndexedProps {
-                iterable: count,
+                iterable: count.handle(),
                 template: |item| template! {
                     li { (item) }
                 },
@@ -132,7 +132,7 @@ fn keyed() {
     let node = cloned!((count) => template! {
         ul {
             Keyed(KeyedProps {
-                iterable: count,
+                iterable: count.handle(),
                 template: |item| template! {
                     li { (item) }
                 },


### PR DESCRIPTION
This PR also includes some bug fixes and QOL improvements discovered while implementing TodoMVC:
- Implement `std::fmt::Debug` for `Signal` and `StateHandle`
- Parse keywords in component path
- Fix parsing of a component followed immediately by an interpolated value
  The following code previously failed to parse:
  ```rust
  template! {
      div {
          MyComponent()
          (interpolated_value)
      }
  }
  ```
  because the interpolated value would be treated as a function call of the previous component.
- Add an `untrack` utility for creating an untracked scope. This is useful when for example, calling a passed in closure and not wanting it to subscribe to current reactive scope.
- Create components inside an `untrack`ed scope (fixes tracking bugs when using `template!` inside interpolated values).
- Implement `PartialEq` for `Signal` and `StateHandle`.
- Implement `Serialize` and `Deserialize` for `Signal` and `StateHandle` only when the `serde` feature is enabled.