### PR TITLE
Add specified easing functions specified in (#88)

### DIFF
--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -103,43 +103,54 @@ pub fn circ_out(t: f32) -> f32 {
 
 pub fn circ_inout(t: f32) -> f32 {
     if t < 0.5 {
-        circ_in(2.*t) / 2.
+        circ_in(2. * t) / 2.
     } else {
-        (1. - (-2.*t + 2.).powi(2)).sqrt() / 2.
+        (1. - (-2. * t + 2.).powi(2)).sqrt() / 2.
     }
 }
 
 // Exponential
 
 pub fn expo_in(t: f32) -> f32 {
-    if t.abs() <= 0.0002 {0.}
-    else {EXP_BASE.powf(10.*t - 10.)}
+    if t.abs() <= 0.0002 {
+        0.
+    } else {
+        EXP_BASE.powf(10. * t - 10.)
+    }
 }
 
 pub fn expo_out(t: f32) -> f32 {
-    if (t - 1.).abs() <= 0.0002 {0.}
-    else {1. - EXP_BASE.powf(-10.*t)}
+    if (t - 1.).abs() <= 0.0002 {
+        0.
+    } else {
+        1. - EXP_BASE.powf(-10. * t)
+    }
 }
 
 pub fn expo_inout(t: f32) -> f32 {
-    if t.abs() <= 0.0002 {0.}
-    else if (t - 1.).abs() <= 0.0002 {1.}
-    else if t <= 0.5 {EXP_BASE.powf(20.*t - 10.) / 2.}
-    else {2. - EXP_BASE.powf(-20.*t + 10.) / 2.}
+    if t.abs() <= 0.0002 {
+        0.
+    } else if (t - 1.).abs() <= 0.0002 {
+        1.
+    } else if t <= 0.5 {
+        EXP_BASE.powf(20. * t - 10.) / 2.
+    } else {
+        2. - EXP_BASE.powf(-20. * t + 10.) / 2.
+    }
 }
 
 // Sine
 
 pub fn sine_in(t: f32) -> f32 {
-    1. - (t*PI/2.).cos()
+    1. - (t * PI / 2.).cos()
 }
 
 pub fn sine_out(t: f32) -> f32 {
-    (t*PI/2.).sin()
+    (t * PI / 2.).sin()
 }
 
 pub fn sine_inout(t: f32) -> f32 {
-    -((PI*t).cos() - 1.) / 2.
+    -((PI * t).cos() - 1.) / 2.
 }
 
 // Bounce
@@ -152,27 +163,26 @@ pub fn bounce_out(t: f32) -> f32 {
     // TODO: Refactor? Code seems like a repetition.
     // Further, it is unclear why the numbers here are
     // picked.
-    if t < 1./BOUNCE_GRAVITY {
+    if t < 1. / BOUNCE_GRAVITY {
         BOUNCE_AMPLITUDE * t * t
-    } else if t < 2./BOUNCE_GRAVITY {
-        let t = 1.5/BOUNCE_GRAVITY;
+    } else if t < 2. / BOUNCE_GRAVITY {
+        let t = 1.5 / BOUNCE_GRAVITY;
         BOUNCE_AMPLITUDE * t * t + 0.75
     } else if t < 2.5 / BOUNCE_GRAVITY {
-        let t = 2.25/BOUNCE_GRAVITY;
-        return BOUNCE_AMPLITUDE * t * t + 0.9375
+        let t = 2.25 / BOUNCE_GRAVITY;
+        BOUNCE_AMPLITUDE * t * t + 0.9375
     } else {
-        let t = 2.625/BOUNCE_GRAVITY;
-        return BOUNCE_AMPLITUDE * t * t + 0.984375
+        let t = 2.625 / BOUNCE_GRAVITY;
+        BOUNCE_AMPLITUDE * t * t + 0.984375
     }
 }
 
 pub fn bounce_inout(t: f32) -> f32 {
     if t < 0.5 {
-        (1. - bounce_out(1. - 2.*t)) / 2.
+        (1. - bounce_out(1. - 2. * t)) / 2.
     } else {
-        (1. + bounce_out(-1. + 2.*t)) / 2.
+        (1. + bounce_out(-1. + 2. * t)) / 2.
     }
 }
-
 
 // TODO: add more easing functions

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -94,18 +94,18 @@ pub fn quint_inout(t: f32) -> f32 {
 // Circular
 
 pub fn circ_in(t: f32) -> f32 {
-    1. - (1. - t.powi(2)).sqrt()
+    1.0 - (1.0 - t.powi(2)).sqrt()
 }
 
 pub fn circ_out(t: f32) -> f32 {
-    (1. - (t - 1.).powi(2)).sqrt()
+    (1.0 - (t - 1.0).powi(2)).sqrt()
 }
 
 pub fn circ_inout(t: f32) -> f32 {
     if t < 0.5 {
-        (1. - (1. - (2. * t).powi(2)).sqrt()) / 2.
+        (1.0 - (1.0 - (2.0 * t).powi(2)).sqrt()) / 2.0
     } else {
-        ((1. - (-2. * t + 2.).powi(2)).sqrt() + 1.) / 2.
+        ((1.0 - (-2.0 * t + 2.).powi(2)).sqrt() + 1.0) / 2.0
     }
 }
 
@@ -120,29 +120,29 @@ pub fn expo_in(t: f32) -> f32 {
 }
 
 pub fn expo_out(t: f32) -> f32 {
-    if (t - 1.).abs() <= 0.0002 {
+    if (t - 1.0).abs() <= 0.0002 {
         0.
     } else {
-        1. - EXP_BASE.powf(-10. * t)
+        1.0 - EXP_BASE.powf(-10. * t)
     }
 }
 
 pub fn expo_inout(t: f32) -> f32 {
     if t.abs() <= 0.0002 {
         0.
-    } else if (t - 1.).abs() <= 0.0002 {
+    } else if (t - 1.0).abs() <= 0.0002 {
         1.
     } else if t <= 0.5 {
-        EXP_BASE.powf(20. * t - 10.) / 2.
+        EXP_BASE.powf(20. * t - 10.) / 2.0
     } else {
-        1. + EXP_BASE.powf(-20. * t + 10.) / -2.
+        1.0 + EXP_BASE.powf(-20. * t + 10.) / -2.0
     }
 }
 
 // Sine
 
 pub fn sine_in(t: f32) -> f32 {
-    1. - (t * PI / 2.).cos()
+    1.0 - (t * PI / 2.0).cos()
 }
 
 pub fn sine_out(t: f32) -> f32 {
@@ -150,22 +150,22 @@ pub fn sine_out(t: f32) -> f32 {
 }
 
 pub fn sine_inout(t: f32) -> f32 {
-    -((PI * t).cos() - 1.) / 2.
+    -((PI * t).cos() - 1.0) / 2.0
 }
 
 // Bounce
 
 pub fn bounce_in(t: f32) -> f32 {
-    1. - bounce_out(1. - t)
+    1.0 - bounce_out(1.0 - t)
 }
 
 pub fn bounce_out(t: f32) -> f32 {
     // TODO: Refactor? Code seems like a repetition.
     // Further, it is unclear why the numbers here are
     // picked.
-    if t < 1. / BOUNCE_GRAVITY {
+    if t < 1.0 / BOUNCE_GRAVITY {
         BOUNCE_AMPLITUDE * t * t
-    } else if t < 2. / BOUNCE_GRAVITY {
+    } else if t < 2.0 / BOUNCE_GRAVITY {
         let t = t - 1.5 / BOUNCE_GRAVITY;
         BOUNCE_AMPLITUDE * t * t + 0.75
     } else if t < 2.5 / BOUNCE_GRAVITY {
@@ -179,9 +179,9 @@ pub fn bounce_out(t: f32) -> f32 {
 
 pub fn bounce_inout(t: f32) -> f32 {
     if t < 0.5 {
-        (1. - bounce_out(1. - 2. * t)) / 2.
+        (1.0 - bounce_out(1.0 - 2.0 * t)) / 2.0
     } else {
-        (1. + bounce_out(-1. + 2. * t)) / 2.
+        (1.0 + bounce_out(-1.0 + 2.0 * t)) / 2.0
     }
 }
 

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -1,5 +1,7 @@
 //! Easing functions.
 
+use core::f32;
+
 // Linear
 
 pub fn linear(t: f32) -> f32 {
@@ -81,6 +83,24 @@ pub fn quint_inout(t: f32) -> f32 {
     } else {
         let f = (2.0 * t) - 2.0;
         0.5 * f * f * f * f * f + 1.0
+    }
+}
+
+// Circular
+
+pub fn circ_in(t: f32) -> f32 {
+    1. - (1. - t.powi(2)).sqrt()
+}
+
+pub fn circ_out(t: f32) -> f32 {
+    (1. - (t - 1.).powi(2)).sqrt()
+}
+
+pub fn circ_inout(t: f32) -> f32 {
+    if t < 0.5 {
+        circ_in(2.*t) / 2.
+    } else {
+        (1. - (-2.*t + 2.).powi(2)).sqrt() / 2.
     }
 }
 

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -103,9 +103,9 @@ pub fn circ_out(t: f32) -> f32 {
 
 pub fn circ_inout(t: f32) -> f32 {
     if t < 0.5 {
-        circ_in(2. * t) / 2.
+        (1. - (1. - (2. * t).powi(2)).sqrt()) / 2.
     } else {
-        (1. - (-2. * t + 2.).powi(2)).sqrt() / 2.
+        ((1. - (-2. * t + 2.).powi(2)).sqrt() + 1.) / 2.
     }
 }
 
@@ -135,7 +135,7 @@ pub fn expo_inout(t: f32) -> f32 {
     } else if t <= 0.5 {
         EXP_BASE.powf(20. * t - 10.) / 2.
     } else {
-        2. - EXP_BASE.powf(-20. * t + 10.) / 2.
+        1. + EXP_BASE.powf(-20. * t + 10.) / -2.
     }
 }
 
@@ -166,13 +166,13 @@ pub fn bounce_out(t: f32) -> f32 {
     if t < 1. / BOUNCE_GRAVITY {
         BOUNCE_AMPLITUDE * t * t
     } else if t < 2. / BOUNCE_GRAVITY {
-        let t = 1.5 / BOUNCE_GRAVITY;
+        let t = t - 1.5 / BOUNCE_GRAVITY;
         BOUNCE_AMPLITUDE * t * t + 0.75
     } else if t < 2.5 / BOUNCE_GRAVITY {
-        let t = 2.25 / BOUNCE_GRAVITY;
+        let t = t - 2.25 / BOUNCE_GRAVITY;
         BOUNCE_AMPLITUDE * t * t + 0.9375
     } else {
-        let t = 2.625 / BOUNCE_GRAVITY;
+        let t = t - 2.625 / BOUNCE_GRAVITY;
         BOUNCE_AMPLITUDE * t * t + 0.984375
     }
 }

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -2,6 +2,8 @@
 
 use core::f32;
 
+const EXP_BASE: f32 = 2.;
+
 // Linear
 
 pub fn linear(t: f32) -> f32 {
@@ -102,6 +104,25 @@ pub fn circ_inout(t: f32) -> f32 {
     } else {
         (1. - (-2.*t + 2.).powi(2)).sqrt() / 2.
     }
+}
+
+// Exponential
+
+pub fn expo_in(t: f32) -> f32 {
+    if t.abs() <= 0.0002 {0.}
+    else {EXP_BASE.powf(10.*t - 10.)}
+}
+
+pub fn expo_out(t: f32) -> f32 {
+    if (t - 1.).abs() <= 0.0002 {0.}
+    else {1. - EXP_BASE.powf(-10.*t)}
+}
+
+pub fn expo_inout(t: f32) -> f32 {
+    if t.abs() <= 0.0002 {0.}
+    else if (t - 1.).abs() <= 0.0002 {1.}
+    else if t <= 0.5 {EXP_BASE.powf(20.*t - 10.) / 2.}
+    else {2. - EXP_BASE.powf(-20.*t + 10.) / 2.}
 }
 
 // TODO: add more easing functions

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -1,6 +1,7 @@
 //! Easing functions.
 
 use core::f32;
+use std::f32::consts::PI;
 
 const EXP_BASE: f32 = 2.;
 
@@ -124,5 +125,20 @@ pub fn expo_inout(t: f32) -> f32 {
     else if t <= 0.5 {EXP_BASE.powf(20.*t - 10.) / 2.}
     else {2. - EXP_BASE.powf(-20.*t + 10.) / 2.}
 }
+
+// Sine
+
+pub fn sine_in(t: f32) -> f32 {
+    1. - (t*PI/2.).cos()
+}
+
+pub fn sine_out(t: f32) -> f32 {
+    (t*PI/2.).sin()
+}
+
+pub fn sine_inout(t: f32) -> f32 {
+    -((PI*t).cos() - 1.) / 2.
+}
+
 
 // TODO: add more easing functions

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -4,6 +4,8 @@ use core::f32;
 use std::f32::consts::PI;
 
 const EXP_BASE: f32 = 2.;
+const BOUNCE_GRAVITY: f32 = 2.75;
+const BOUNCE_AMPLITUDE: f32 = 7.5625;
 
 // Linear
 
@@ -138,6 +140,38 @@ pub fn sine_out(t: f32) -> f32 {
 
 pub fn sine_inout(t: f32) -> f32 {
     -((PI*t).cos() - 1.) / 2.
+}
+
+// Bounce
+
+pub fn bounce_in(t: f32) -> f32 {
+    1. - bounce_out(1. - t)
+}
+
+pub fn bounce_out(t: f32) -> f32 {
+    // TODO: Refactor? Code seems like a repetition.
+    // Further, it is unclear why the numbers here are
+    // picked.
+    if t < 1./BOUNCE_GRAVITY {
+        BOUNCE_AMPLITUDE * t * t
+    } else if t < 2./BOUNCE_GRAVITY {
+        let t = 1.5/BOUNCE_GRAVITY;
+        BOUNCE_AMPLITUDE * t * t + 0.75
+    } else if t < 2.5 / BOUNCE_GRAVITY {
+        let t = 2.25/BOUNCE_GRAVITY;
+        return BOUNCE_AMPLITUDE * t * t + 0.9375
+    } else {
+        let t = 2.625/BOUNCE_GRAVITY;
+        return BOUNCE_AMPLITUDE * t * t + 0.984375
+    }
+}
+
+pub fn bounce_inout(t: f32) -> f32 {
+    if t < 0.5 {
+        (1. - bounce_out(1. - 2.*t)) / 2.
+    } else {
+        (1. + bounce_out(-1. + 2.*t)) / 2.
+    }
 }
 
 

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -112,7 +112,7 @@ pub fn circ_inout(t: f32) -> f32 {
 // Exponential
 
 pub fn expo_in(t: f32) -> f32 {
-    if t.abs() <= 0.0002 {
+    if t.abs() <= f32::EPSILON {
         0.
     } else {
         EXP_BASE.powf(10. * t - 10.)
@@ -120,7 +120,7 @@ pub fn expo_in(t: f32) -> f32 {
 }
 
 pub fn expo_out(t: f32) -> f32 {
-    if (t - 1.0).abs() <= 0.0002 {
+    if (t - 1.0).abs() <= f32::EPSILON {
         0.
     } else {
         1.0 - EXP_BASE.powf(-10. * t)
@@ -128,9 +128,9 @@ pub fn expo_out(t: f32) -> f32 {
 }
 
 pub fn expo_inout(t: f32) -> f32 {
-    if t.abs() <= 0.0002 {
+    if t.abs() <= f32::EPSILON {
         0.
-    } else if (t - 1.0).abs() <= 0.0002 {
+    } else if (t - 1.0).abs() <= f32::EPSILON {
         1.
     } else if t <= 0.5 {
         EXP_BASE.powf(20. * t - 10.) / 2.0

--- a/maple-core/src/easing.rs
+++ b/maple-core/src/easing.rs
@@ -94,18 +94,18 @@ pub fn quint_inout(t: f32) -> f32 {
 // Circular
 
 pub fn circ_in(t: f32) -> f32 {
-    1.0 - (1.0 - t.powi(2)).sqrt()
+    1.0 - f32::sqrt(1.0 - f32::powi(t, 2))
 }
 
 pub fn circ_out(t: f32) -> f32 {
-    (1.0 - (t - 1.0).powi(2)).sqrt()
+    f32::sqrt(1.0 - f32::powi(t - 1.0, 2).powi(2))
 }
 
 pub fn circ_inout(t: f32) -> f32 {
     if t < 0.5 {
-        (1.0 - (1.0 - (2.0 * t).powi(2)).sqrt()) / 2.0
+        (1.0 - f32::sqrt(1.0 - f32::powi(2.0 * t, 2))) / 2.0
     } else {
-        ((1.0 - (-2.0 * t + 2.).powi(2)).sqrt() + 1.0) / 2.0
+        (f32::sqrt(1.0 - f32::powi(-2.0 * t + 2.0, 2)) + 1.0) / 2.0
     }
 }
 
@@ -130,27 +130,27 @@ pub fn expo_out(t: f32) -> f32 {
 pub fn expo_inout(t: f32) -> f32 {
     if t.abs() <= f32::EPSILON {
         0.
-    } else if (t - 1.0).abs() <= f32::EPSILON {
+    } else if (t - 1.0) <= f32::EPSILON {
         1.
     } else if t <= 0.5 {
-        EXP_BASE.powf(20. * t - 10.) / 2.0
+        f32::powf(EXP_BASE, 20. * t - 10.) / 2.0
     } else {
-        1.0 + EXP_BASE.powf(-20. * t + 10.) / -2.0
+        1.0 + f32::powf(EXP_BASE, -20. * t + 10.) / -2.0
     }
 }
 
 // Sine
 
 pub fn sine_in(t: f32) -> f32 {
-    1.0 - (t * PI / 2.0).cos()
+    f32::cos(1.0 - (t * PI / 2.0))
 }
 
 pub fn sine_out(t: f32) -> f32 {
-    (t * PI / 2.).sin()
+    f32::sin(t * PI / 2.0)
 }
 
 pub fn sine_inout(t: f32) -> f32 {
-    -((PI * t).cos() - 1.0) / 2.0
+    -(f32::cos(PI * t) - 1.0) / 2.0
 }
 
 // Bounce


### PR DESCRIPTION
### What was added

Functions for circular, sine, exponential and bouncing easing have been added to `easing.rs`. Further, I added 3 constants. This doesn't have to close (#88), since one could still add functions.

### Remarks

- I took most functions from [https://easings.net/](here), yet had no idea yet how to test the functions.
- A few things about the bouncing easing could be added improved:
     -  One could clarify the choice of numbers
     - Some of the code could be more compact and more configurable.